### PR TITLE
Custom tips loaded from .json file

### DIFF
--- a/src/main/java/com/bedrocklegends/blt/client/TipRenderer.java
+++ b/src/main/java/com/bedrocklegends/blt/client/TipRenderer.java
@@ -1,0 +1,60 @@
+package com.bedrocklegends.blt.client;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraftforge.fml.loading.FMLPaths;
+
+import java.awt.*;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+/* @author lazyMods */
+public class TipRenderer {
+
+    public String tipTile;
+    public String tip;
+    private static int tipTitleColor = Color.RED.getRGB();
+    private static int tipColor = Color.WHITE.getRGB();
+
+    private static MatrixStack stack = new MatrixStack();
+
+    public TipRenderer(String tipTile, String tip) {
+        this.tipTile = tipTile;
+        this.tip = tip;
+    }
+
+    public static TipRenderer getTip() {
+        Map<String, String> tips = getTips();
+        int randomIndex = new Random().nextInt(tips.size());
+        String key = new ArrayList<>(tips.keySet()).get(randomIndex);
+        return new TipRenderer(key, tips.get(key));
+    }
+
+    public static void renderTipOnScreen(Screen screen, String tipTitle, String tip) {
+        screen.getMinecraft().fontRenderer.func_243246_a(stack, new StringTextComponent(tipTitle), 10, screen.height - 35, tipTitleColor);
+        screen.getMinecraft().fontRenderer.func_243246_a(stack, new StringTextComponent(tip), 10, screen.height - 20, tipColor);
+    }
+
+    private static Map<String, String> getTips() {
+        File tipFile = new File(FMLPaths.GAMEDIR.get() + "/tips.json");
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        if (!Files.exists(tipFile.toPath())) return new HashMap<>();
+        try {
+            return gson.fromJson(new FileReader(tipFile), new TypeToken<HashMap<String, String>>() {
+            }.getType());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return new HashMap<>();
+    }
+}

--- a/src/main/java/com/bedrocklegends/blt/client/event/GuiScreenListener.java
+++ b/src/main/java/com/bedrocklegends/blt/client/event/GuiScreenListener.java
@@ -1,16 +1,29 @@
 package com.bedrocklegends.blt.client.event;
 
+import com.bedrocklegends.blt.client.TipRenderer;
 import com.bedrocklegends.blt.client.widget.ConfigButton;
+import net.minecraft.client.gui.screen.DirtMessageScreen;
 import net.minecraft.client.gui.screen.MainMenuScreen;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.WorldLoadProgressScreen;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 /* @author lazyMods */
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
-public class RenderConfigButton {
+public class GuiScreenListener {
+
+    private static TipRenderer chosenTip;
+
+    @SubscribeEvent
+    public static void onGuiOpen(GuiOpenEvent event) {
+        Screen screen = event.getGui();
+        if (screen instanceof WorldLoadProgressScreen)
+            chosenTip = TipRenderer.getTip();
+    }
 
     @SubscribeEvent
     public static void onGuiPostInit(GuiScreenEvent.InitGuiEvent.Post event) {
@@ -20,5 +33,12 @@ public class RenderConfigButton {
                 event.addWidget(new ConfigButton(screen.width - 22, 2));
             }
         }
+    }
+
+    @SubscribeEvent
+    public static void onGuiPostDraw(GuiScreenEvent.DrawScreenEvent.Post event) {
+        Screen screen = event.getGui();
+        if (screen instanceof WorldLoadProgressScreen)
+            TipRenderer.renderTipOnScreen(screen, chosenTip.tipTile, chosenTip.tip);
     }
 }


### PR DESCRIPTION
### How it works

- Put a .json file named **"tips"** in the game folder with all the tips like this

![imagem](https://user-images.githubusercontent.com/52864251/94866218-ce405600-0436-11eb-9662-cf293096145b.png)

**PS:** If the game doesn´t find the file, anything will appear on the world loading because the list of tips became empty.

### TODO

- Implement custom styling (Position, tip color, and tip title color)
- Solution for custom tips on the Mojang loading screen, since we don´t have space to do it. (If it's really necessary)

### Example working

![imagem](https://user-images.githubusercontent.com/52864251/94866600-94bc1a80-0437-11eb-8fe3-b12de9d70278.png)

