### PR TITLE
Tip bugs

### DIFF
--- a/src/main/java/com/bedrocklegends/blt/client/DarkUIResourcePackCreation.java
+++ b/src/main/java/com/bedrocklegends/blt/client/DarkUIResourcePackCreation.java
@@ -1,4 +1,4 @@
-package com.bedrocklegends.blt.client.event;
+package com.bedrocklegends.blt.client;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.ResourceLocation;

--- a/src/main/java/com/bedrocklegends/blt/client/TipRenderer.java
+++ b/src/main/java/com/bedrocklegends/blt/client/TipRenderer.java
@@ -28,6 +28,8 @@ public class TipRenderer {
 
     private static MatrixStack stack = new MatrixStack();
 
+    private static final TipRenderer BLANK = new TipRenderer("", "");
+
     public TipRenderer(String tipTile, String tip) {
         this.tipTile = tipTile;
         this.tip = tip;
@@ -35,9 +37,12 @@ public class TipRenderer {
 
     public static TipRenderer getTip() {
         Map<String, String> tips = getTips();
-        int randomIndex = new Random().nextInt(tips.size());
-        String key = new ArrayList<>(tips.keySet()).get(randomIndex);
-        return new TipRenderer(key, tips.get(key));
+        if(tips.size() > 0){
+            int randomIndex = new Random().nextInt(tips.size());
+            String key = new ArrayList<>(tips.keySet()).get(randomIndex);
+            return new TipRenderer(key, tips.get(key));
+        }
+        return BLANK;
     }
 
     public static void renderTipOnScreen(Screen screen, String tipTitle, String tip) {

--- a/src/main/java/com/bedrocklegends/blt/client/event/GuiScreenListener.java
+++ b/src/main/java/com/bedrocklegends/blt/client/event/GuiScreenListener.java
@@ -1,8 +1,8 @@
 package com.bedrocklegends.blt.client.event;
 
 import com.bedrocklegends.blt.client.TipRenderer;
+import com.bedrocklegends.blt.client.screen.ConfigsScreen;
 import com.bedrocklegends.blt.client.widget.ConfigButton;
-import net.minecraft.client.gui.screen.DirtMessageScreen;
 import net.minecraft.client.gui.screen.MainMenuScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.WorldLoadProgressScreen;
@@ -11,6 +11,8 @@ import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+
+import java.util.Map;
 
 /* @author lazyMods */
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
@@ -21,8 +23,13 @@ public class GuiScreenListener {
     @SubscribeEvent
     public static void onGuiOpen(GuiOpenEvent event) {
         Screen screen = event.getGui();
-        if (screen instanceof WorldLoadProgressScreen)
-            chosenTip = TipRenderer.getTip();
+
+        if (screen instanceof WorldLoadProgressScreen) {
+            Map<String, Object> configs = ConfigsScreen.populateConfigs();
+            if ((boolean) configs.get(ConfigsScreen.RENDER_TIPS)) {
+                chosenTip = TipRenderer.getTip();
+            }
+        }
     }
 
     @SubscribeEvent
@@ -38,7 +45,12 @@ public class GuiScreenListener {
     @SubscribeEvent
     public static void onGuiPostDraw(GuiScreenEvent.DrawScreenEvent.Post event) {
         Screen screen = event.getGui();
-        if (screen instanceof WorldLoadProgressScreen)
-            TipRenderer.renderTipOnScreen(screen, chosenTip.tipTile, chosenTip.tip);
+
+        if (screen instanceof WorldLoadProgressScreen) {
+            Map<String, Object> configs = ConfigsScreen.populateConfigs();
+            if ((boolean) configs.get(ConfigsScreen.RENDER_TIPS)) {
+                TipRenderer.renderTipOnScreen(screen, chosenTip.tipTile, chosenTip.tip);
+            }
+        }
     }
 }

--- a/src/main/java/com/bedrocklegends/blt/client/screen/ConfigsScreen.java
+++ b/src/main/java/com/bedrocklegends/blt/client/screen/ConfigsScreen.java
@@ -1,7 +1,6 @@
 package com.bedrocklegends.blt.client.screen;
 
-import com.bedrocklegends.blt.client.event.DarkUIResourcePackCreation;
-import com.google.common.collect.ImmutableMap;
+import com.bedrocklegends.blt.client.DarkUIResourcePackCreation;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
@@ -21,26 +20,35 @@ import java.util.Map;
 /* @author lazyMods */
 public class ConfigsScreen extends Screen {
 
-    private Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
     private Map<String, Object> configs;
 
-    private final String DARK_UI = "dark_ui";
+    public static final String DARK_UI = "dark_ui";
+    public static final String RENDER_TIPS = "render_tips";
 
     public ConfigsScreen() {
         super(new StringTextComponent("BedrockLegends Tweaks"));
-        this.configs = this.populateConfigs();
+        this.configs = populateConfigs();
     }
 
     @Override
     protected void init() {
         super.init();
-        this.addButton(new CheckboxButton(20, 40, 150, 20, new StringTextComponent("Dark Mode UI"), (boolean) configs.get(DARK_UI)) {
+        this.addButton(new CheckboxButton(20, 40, 150, 20, new StringTextComponent("Dark Mode UI"), this.checkAndReturnBoolean(DARK_UI)) {
             @Override
             public void onPress() {
                 super.onPress();
                 DarkUIResourcePackCreation.reload(this.isChecked());
                 configs.put(DARK_UI, this.isChecked());
+                saveConfigs();
+            }
+        });
+        this.addButton(new CheckboxButton(20, 60, 150, 20, new StringTextComponent("Show tips when loading the world."), this.checkAndReturnBoolean(RENDER_TIPS)) {
+            @Override
+            public void onPress() {
+                super.onPress();
+                configs.put(RENDER_TIPS, this.isChecked());
                 saveConfigs();
             }
         });
@@ -54,6 +62,10 @@ public class ConfigsScreen extends Screen {
         super.render(matrixStack, mouseX, mouseY, partialTicks);
     }
 
+    public boolean checkAndReturnBoolean(String key){
+        return this.configs.containsKey(key) ? (Boolean)this.configs.get(key) : false;
+    }
+
     public void saveConfigs() {
         try {
             File map = new File(FMLPaths.GAMEDIR.get() + "/blt_configs.json");
@@ -65,15 +77,16 @@ public class ConfigsScreen extends Screen {
         }
     }
 
-    private Map<String, Object> populateConfigs() {
-        Map<String, Object> configs = null;
+    public static Map<String, Object> populateConfigs() {
+        Map<String, Object> configs = new HashMap<>();
         try {
             File bltconfigs = new File(FMLPaths.GAMEDIR.get() + "/blt_configs.json");
             if(!Files.exists(Paths.get(bltconfigs.toURI()))){
                 configs = new HashMap<>();
                 configs.put(DARK_UI, false);
+                configs.put(RENDER_TIPS, true);
             } else {
-                configs = GSON.fromJson(new FileReader(bltconfigs), new TypeToken<Map<String, Object>>() {
+                return GSON.fromJson(new FileReader(bltconfigs), new TypeToken<Map<String, Object>>() {
                 }.getType());
             }
         } catch (FileNotFoundException e) {

--- a/src/main/java/com/bedrocklegends/blt/proxy/ClientProxy.java
+++ b/src/main/java/com/bedrocklegends/blt/proxy/ClientProxy.java
@@ -4,7 +4,7 @@ package com.bedrocklegends.blt.proxy;
 import com.bedrocklegends.blt.DRP;
 import com.bedrocklegends.blt.UpdateDRP;
 
-import com.bedrocklegends.blt.client.event.DarkUIResourcePackCreation;
+import com.bedrocklegends.blt.client.DarkUIResourcePackCreation;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.world.World;


### PR DESCRIPTION
### Quick fixes

- Added config to disable tips
- Crash fix: TipRenderer trying to get tips when the tips file doesn't contain tips. 
  -  Reason: **random.nextInt** bound should be greater than 1.